### PR TITLE
Fix typo

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -1988,7 +1988,7 @@ of (not shown) padding bytes and can be ignored.
 			<ul>
 			<li><tt>15</tt> - type is 0x15 (alert record)
 			<li><tt>03 03</tt> - protocol version is 3.3 (TLS 1.2)
-			<li><tt>00 31</tt> - the length of the record payload is 0x30 (48) bytes
+			<li><tt>00 30</tt> - the length of the record payload is 0x30 (48) bytes
 			</ul>
 			All data following this header is the payload for this record.
 		</div>


### PR DESCRIPTION
application data length is 48 (0x30), not 49 (0x31)