### PR TITLE
Extract OID length field for "Country" and "OrganizationalUnit"

### DIFF
--- a/generate/certificate.html.template
+++ b/generate/certificate.html.template
@@ -145,7 +145,8 @@
             <li><tt>%2</tt> - constructed universal type sequence
             <li><tt>%3</tt> - sequence length of %x3 (%d3) bytes
             <li><tt>%4</tt> - universal type object ID (OID)
-            <li><tt>%5 %6 %7 %8</tt> - OID 2.5.4.6 "Country"
+            <li><tt>%5</tt> - OID length %x5 (%d5) bytes
+            <li><tt>%6 %7 %8</tt> - OID 2.5.4.6 "Country"
             <li><tt>%9</tt> - universal type printablestring
             <li><tt>%10</tt> - printable string length %x10 (%d10) bytes
             <li><tt>%11 %12</tt> - "US"
@@ -167,7 +168,8 @@
             <li><tt>%2</tt> - constructed universal type sequence
             <li><tt>%3</tt> - sequence length of %x3 (%d3) bytes
             <li><tt>%4</tt> - universal type object ID (OID)
-            <li><tt>%5 %6 %7 %8</tt> - OID 2.5.4.10 "OrganizationalUnit"
+            <li><tt>%5</tt> - OID length %x5 (%d5) bytes
+            <li><tt>%6 %7 %8</tt> - OID 2.5.4.10 "OrganizationalUnit"
             <li><tt>%9</tt> - universal type printablestring
             <li><tt>%10</tt> - printable string length %x10 (%d10) bytes
             <li><tt>%11 %12 %13 %14 %15 %16 %17 %18 %19 %20</tt> - "Example CA"

--- a/site/certificate.html
+++ b/site/certificate.html
@@ -136,7 +136,8 @@
             <li><tt>30</tt> - constructed universal type sequence
             <li><tt>09</tt> - sequence length of 0x9 (9) bytes
             <li><tt>06</tt> - universal type object ID (OID)
-            <li><tt>03 55 04 06</tt> - OID 2.5.4.6 "Country"
+            <li><tt>03</tt> - OID length 0x3 (3) bytes
+            <li><tt>55 04 06</tt> - OID 2.5.4.6 "Country"
             <li><tt>13</tt> - universal type printablestring
             <li><tt>02</tt> - printable string length 0x2 (2) bytes
             <li><tt>55 53</tt> - "US"
@@ -157,7 +158,8 @@
             <li><tt>30</tt> - constructed universal type sequence
             <li><tt>11</tt> - sequence length of 0x11 (17) bytes
             <li><tt>06</tt> - universal type object ID (OID)
-            <li><tt>03 55 04 0a</tt> - OID 2.5.4.10 "OrganizationalUnit"
+            <li><tt>03</tt> - OID length 0x3 (3) bytes
+            <li><tt>55 04 0a</tt> - OID 2.5.4.10 "OrganizationalUnit"
             <li><tt>13</tt> - universal type printablestring
             <li><tt>0a</tt> - printable string length 0xA (10) bytes
             <li><tt>45 78 61 6d 70 6c 65 20 43 41</tt> - "Example CA"


### PR DESCRIPTION
The Country and OrganizationalUnit templates used the OID Length field inside the OID definition. This pull request removes the OID length field from the OID field and places it before the OID field. This is more consistent with other fields like the "Common Name"

Thanks for the great visualisation of the TLS1.2 connection. Must have taken quite some time to build these. IEEE should fund you to do this for all sort of other protocols!
